### PR TITLE
fix/search-modal-wrapper

### DIFF
--- a/src/components/PageContent/index.tsx
+++ b/src/components/PageContent/index.tsx
@@ -17,6 +17,12 @@ export default function PageContent({
   setActiveTheme,
 }: ActiveThemeProps) {
   const dispatch = useAppDispatch();
+  const isModalOpen = useAppSelector((state) => state.modal.searchMode);
+
+  // 防滾動
+  useEffect(() => {
+    document.body.style.overflow = isModalOpen ? "hidden" : "auto";
+  }, [isModalOpen]);
 
   // initialize localStorage
   useEffect(() => {

--- a/src/components/SearchModal/styled.tsx
+++ b/src/components/SearchModal/styled.tsx
@@ -5,7 +5,7 @@ import breakpoint from "../../constants/style/breakpoint";
 
 // Modal
 export const Wrapper = styled.div<IsModalOpen>`
-  position: absolute;
+  position: fixed;
 
   display: none;
   justify-content: center;


### PR DESCRIPTION
### 狀況
SearchModal 元件會跟著畫面滾動上下位移
應固定在瀏覽器可視畫面上，並且畫面不可滾動

### 修正
- 調整 SearchModal Wrapper 樣式
- 增加對 body overflow 的處理